### PR TITLE
update port syntax for docker 0.6.5+

### DIFF
--- a/booktype/Dockerfile
+++ b/booktype/Dockerfile
@@ -39,7 +39,7 @@ add	./settings.py /mybook/settings.py
 add     ./run-supervisord /usr/sbin/run-supervisord
 add	./booktype.okfn.org.conf /etc/supervisor/conf.d/booktype.okfn.org.conf
 
-expose  :8000
+expose  8000
 
 cmd     ["/usr/sbin/run-supervisord"]
 

--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -16,7 +16,7 @@ run	git clone https://github.com/ether/etherpad-lite.git /src/etherpad-lite
 add	./settings.json /src/etherpad-lite/settings.json
 run	/src/etherpad-lite/bin/installDeps.sh
 
-expose	:9001
+expose	9001
 
 entrypoint	["/src/etherpad-lite/bin/run.sh", "--root"]
 

--- a/graphite/Dockerfile
+++ b/graphite/Dockerfile
@@ -27,13 +27,13 @@ run	chmod 0664 /var/lib/graphite/storage/graphite.db
 run	cd /var/lib/graphite/webapp/graphite && python manage.py syncdb --noinput
 
 # Nginx
-expose	:80
+expose	80
 # Carbon line receiver port
-expose	:2003
+expose	2003
 # Carbon pickle receiver port
-expose	:2004
+expose	2004
 # Carbon cache query port
-expose	:7002
+expose	7002
 
 cmd	["/usr/bin/supervisord"]
 

--- a/graphiti/Dockerfile
+++ b/graphiti/Dockerfile
@@ -17,9 +17,9 @@ add	./unicorn.rb /src/graphiti/config/unicorn.rb
 add	./settings.yml /src/graphiti/config/settings.yml
 
 # Unicorn port
-expose	:8080
+expose	8080
 # Redis port
-expose	:6379
+expose	6379
 
 cmd	["/usr/bin/supervisord"]
 

--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -14,10 +14,10 @@ add	./mongodb.conf /etc/mongodb.conf
 add	./start /src/start
 
 # Mongo port
-expose	:27017
+expose	27017
 # NB: if run with the environment variable REPLSETMEMBERS, this container will
 # start multiple instances of mongod on ports 27017, 27018, 27019, etc. You will
-# need to manually open the ports with "docker run -p 27017 -p 27018 ...".
+# need to manually open the ports with "docker run -expose 27017 -expose 27018 ...".
 
 cmd	["sh", "/src/start"]
 

--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -22,9 +22,9 @@ add	./config.js /src/statsd/config.js
 ##
 
 # Statsd UDP port
-expose	:8125
+expose	8125/udp
 # Statsd Management port
-expose	:8126
+expose	8126
 
 cmd	["/usr/bin/node", "/src/statsd/stats.js", "/src/statsd/config.js"]
 


### PR DESCRIPTION
This updates the Dockerfile syntax to the 0.6.5+-style Dockerfile syntax, and correctly exposes the udp port in the statsd Dockerfile.
